### PR TITLE
Avoid attempt to fill nan on integer array

### DIFF
--- a/bnn_priors/exp_utils.py
+++ b/bnn_priors/exp_utils.py
@@ -509,7 +509,7 @@ class HDF5Metrics(HDF5ModelSaver):
 
         elif step < self._step:
             raise ValueError(f"step went backwards ({self._step} -> {step})")
-        self._append(name, value, type(value))
+        self._append(name, value, np.float64)
 
     def _scrub_cache(self):
         for v in self._cache.values():


### PR DESCRIPTION
On https://github.com/ratschlab/bnn_priors/blob/main/bnn_priors/exp_utils.py#L523 it fills the array with NaNs, but it fails when the array type is int (https://stackoverflow.com/questions/12708807/numpy-integer-nan). I propose to always save scalars as floats avoiding this exception.